### PR TITLE
Fixed getValue() math error

### DIFF
--- a/src/plugins/nextion/nextionService.js
+++ b/src/plugins/nextion/nextionService.js
@@ -135,7 +135,7 @@ export default class NextionService extends EventEmitter{
   
   async getValue(cmp){
     var result = await this._writeUart('get '+cmp, true);
-    return result[0];
+    return (result[1]*256+result[0]);
   }
 
   async displayBlackWhiteImage(buffer, positionX, positionY, width){


### PR DESCRIPTION
Fixed 16bit integer return from getValue(), it was just returning lower
byte of data.